### PR TITLE
Update Rockarolla runtime to 46

### DIFF
--- a/ar.com.softwareperonista.Rockarrolla.json
+++ b/ar.com.softwareperonista.Rockarrolla.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "ar.com.softwareperonista.Rockarrolla",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "rockarrolla",
     "finish-args" : [

--- a/ar.com.softwareperonista.Rockarrolla.json
+++ b/ar.com.softwareperonista.Rockarrolla.json
@@ -74,6 +74,10 @@
                     "type" : "archive",
                     "url" : "https://gitlab.com/softwareperonista/rockarrolla/-/archive/1.4/rockarrolla-1.4.tar.gz",
                     "sha256" : "5443574334abef1f397dfb06e62efab6e75934e0aa4de3bdc6def8f707ca3a13"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,35 @@
+From 180bdb2ac9ff19365338f7950cb5930334dc6c04 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 8 Jun 2024 19:36:53 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/ar.com.softwareperonista.Rockarrolla.appdata.xml.in | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/data/ar.com.softwareperonista.Rockarrolla.appdata.xml.in b/data/ar.com.softwareperonista.Rockarrolla.appdata.xml.in
+index c474593..1897d17 100644
+--- a/data/ar.com.softwareperonista.Rockarrolla.appdata.xml.in
++++ b/data/ar.com.softwareperonista.Rockarrolla.appdata.xml.in
+@@ -15,7 +15,6 @@
+   <categories>
+     <category>Audio</category>
+     <category>Music</category>
+-    <category>Jukebox</category>
+   </categories>
+   <screenshots>
+     <screenshot type="default">
+@@ -33,6 +32,9 @@
+     <release version="1.2" date="2021-12-12"/>
+     <release version="1.0" date="2021-07-07"/>
+   </releases>
++  <developer_name>Software Peronista</developer_name>
+   <url type="homepage">https://gitlab.com/softwareperonista/rockarrolla</url>
++  <url type="bugtracker">https://gitlab.com/softwareperonista/rockarrolla/-/issues</url>
++  <url type="vcs-browser">https://gitlab.com/softwareperonista/rockarrolla</url>
+   <update_contact>desarrolladores@softwareperonista.com.ar</update_contact>
+ </component>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update Rockarrolla runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts
