### PR TITLE
Update runtime to 47

### DIFF
--- a/ar.com.softwareperonista.Rockarrolla.json
+++ b/ar.com.softwareperonista.Rockarrolla.json
@@ -32,8 +32,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/softwareperonista/doctrina/-/archive/0.1.13.2/doctrina-0.1.13.2.tar.gz",
-                    "sha256" : "d9863cf3a3eddbd5738509b434a949ae2a6e66de9b6687505d62cd767fe27955"
+                    "url" : "https://gitlab.com/softwareperonista/doctrina/-/archive/0.1.14.0/doctrina-0.1.14.0.tar.gz",
+                    "sha256" : "77996aef64a658b118b1b3fdcc8130b5f37a64d69363918a6e6eca53fb2af1e1"                    
                 }
             ]
         },

--- a/ar.com.softwareperonista.Rockarrolla.json
+++ b/ar.com.softwareperonista.Rockarrolla.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "ar.com.softwareperonista.Rockarrolla",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "rockarrolla",
     "finish-args" : [


### PR DESCRIPTION
- Update GNOME runtime to 47
- Update doctrina version to 0.1.14.0

Source: https://gitlab.com/softwareperonista/rockarrolla/-/merge_requests/115